### PR TITLE
Test in Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
     - name: Start from clean state
       run: make clean
     - name: Run tests
-      run: make check
+      run: make PYTHON3=python check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [ 3.6, 3.8 ]
 
     steps:
     - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@
 
 SHELL := /bin/bash
 
+PYTHON3 ?= $(shell which python3.9 2>/dev/null || which python3.8 2>/dev/null || which python3.7 2>/dev/null || which python3.6 2>/dev/null || which python3)
+
 all:
 
 .PHONY: \
@@ -38,6 +40,7 @@ all:
 check: \
   .git_submodule_init.done.log
 	$(MAKE) \
+	  PYTHON3=$(PYTHON3) \
 	  --directory tests \
 	  check
 

--- a/tests/case_file/Makefile
+++ b/tests/case_file/Makefile
@@ -96,8 +96,11 @@ kb.ttl: \
 	mv _$@ $@
 
 sample.txt.done.log: \
+  $(tests_srcdir)/.venv.done.log \
   sample_txt.py
-	python3 sample_txt.py sample.txt
+	source $(tests_srcdir)/venv/bin/activate \
+	  && python3 sample_txt.py \
+	    sample.txt
 	touch $@
 
 # Display difference between rdflib default output and compacted output.

--- a/tests/case_file/sample_txt.py
+++ b/tests/case_file/sample_txt.py
@@ -17,13 +17,14 @@ This file is made with a Python script instead of 'echo' and 'touch' in order to
 Mtime should be 2010-01-02T03:04:56Z.
 """
 
-import datetime
 import os
 import sys
+
+import dateutil.parser
 
 with open(sys.argv[1], "w") as out_fh:
     out_fh.write("test")
 
-target_datetime = datetime.datetime.fromisoformat("2010-01-02T03:04:56+00:00")
+target_datetime = dateutil.parser.isoparse("2010-01-02T03:04:56+00:00")
 target_timestamp = target_datetime.timestamp()
 os.utime(sys.argv[1], (target_timestamp, target_timestamp))

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 PyLD
 pytest
+python-dateutil


### PR DESCRIPTION
The Python Software Foundation is supporting Python 3.6 until
2021-12-23.

CASE should test its tooling in Python 3.6 until that Python release
reaches end-of-life.

This patch is somewhat an XFAIL - I ran the unit tests in an Ubuntu
18.04 machine and found a feature used in a test is supported in
Python >= 3.7.  A follow-on patch will correct that issue.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>