### PR TITLE
Import compact.py fixes

### DIFF
--- a/tests/case_file/kb.json
+++ b/tests/case_file/kb.json
@@ -4,7 +4,8 @@
         "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
         "uco-core": "https://unifiedcyberontology.org/ontology/uco/core#",
         "uco-observable": "https://unifiedcyberontology.org/ontology/uco/observable#",
-        "uco-types": "https://unifiedcyberontology.org/ontology/uco/types#"
+        "uco-types": "https://unifiedcyberontology.org/ontology/uco/types#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {

--- a/tests/src/compact.py
+++ b/tests/src/compact.py
@@ -64,6 +64,10 @@ def main():
         _logger.debug("total_context = %r." % total_context)
 
         compacted = pyld.jsonld.compact(doc, total_context)
+
+        # Add xsd prefix back in to context dictionary.  .compact() removes it, and this causes some xsd definitions like xsd:long to no longer resolve in SPARQL queries.
+        compacted["@context"]["xsd"] = "http://www.w3.org/2001/XMLSchema#"
+
         out_fh.write(json.dumps(compacted, indent=4))
 
 if __name__ == "__main__":


### PR DESCRIPTION
I've started adopting the utilities repository in other Python projects on casework. Some of the projects had their own copies of utility scripts, and have fallen out of sync. tests/src/compact.py had some updates in the ExifTool implementation. This PR will import those updates.

First, the PR is being opened to run CI.