### PR TITLE
Use pip -e flag

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -37,10 +37,6 @@ all: \
 .venv.done.log: \
   $(top_srcdir)/.git_submodule_init.done.log \
   $(top_srcdir)/case_utils/__init__.py \
-  $(top_srcdir)/case_utils/case_file/__init__.py \
-  $(top_srcdir)/case_utils/case_sparql_construct/__init__.py \
-  $(top_srcdir)/case_utils/case_sparql_select/__init__.py \
-  $(top_srcdir)/case_utils/local_uuid.py \
   $(top_srcdir)/setup.cfg \
   $(top_srcdir)/setup.py \
   requirements.txt
@@ -58,7 +54,9 @@ all: \
 	    --requirement requirements.txt
 	source venv/bin/activate \
 	  && cd $(top_srcdir) \
-	    && python3 setup.py install
+	    && pip install \
+	      --editable \
+	      .
 	touch $@
 
 all-case_file: \

--- a/tests/case_file/Makefile
+++ b/tests/case_file/Makefile
@@ -105,6 +105,8 @@ sample.txt.done.log: \
 sample.txt.json: \
   $(tests_srcdir)/src/compact.py \
   $(tests_srcdir)/src/isomorphic_diff.py \
+  $(top_srcdir)/case_utils/case_file/__init__.py \
+  $(top_srcdir)/case_utils/local_uuid.py \
   sample.txt-nocompact.json
 	rm -f $@ _$@ __$@
 	export DEMO_UUID_REQUESTING_NONRANDOM=NONRANDOM_REQUESTED \
@@ -135,6 +137,7 @@ sample.txt.ttl: \
   $(RDF_TOOLKIT_JAR) \
   $(tests_srcdir)/.venv.done.log \
   $(top_srcdir)/case_utils/case_file/__init__.py \
+  $(top_srcdir)/case_utils/local_uuid.py \
   sample.txt.done.log
 	rm -f _$@ __$@
 	export DEMO_UUID_REQUESTING_NONRANDOM=NONRANDOM_REQUESTED \
@@ -156,6 +159,7 @@ sample.txt-disable_hashes.ttl: \
   $(RDF_TOOLKIT_JAR) \
   $(tests_srcdir)/.venv.done.log \
   $(top_srcdir)/case_utils/case_file/__init__.py \
+  $(top_srcdir)/case_utils/local_uuid.py \
   sample.txt.done.log
 	rm -f _$@ __$@
 	export DEMO_UUID_REQUESTING_NONRANDOM=NONRANDOM_REQUESTED \
@@ -179,6 +183,7 @@ sample.txt-nocompact.json: \
   $(tests_srcdir)/.venv.done.log \
   $(tests_srcdir)/src/isomorphic_diff.py \
   $(top_srcdir)/case_utils/case_file/__init__.py \
+  $(top_srcdir)/case_utils/local_uuid.py \
   sample.txt.done.log
 	rm -f _$@
 	export DEMO_UUID_REQUESTING_NONRANDOM=NONRANDOM_REQUESTED \

--- a/tests/case_sparql_construct/Makefile
+++ b/tests/case_sparql_construct/Makefile
@@ -35,6 +35,7 @@ clean:
 
 output.ttl: \
   $(tests_srcdir)/.venv.done.log \
+  $(top_srcdir)/case_utils/case_sparql_construct/__init__.py \
   input-1.sparql \
   input-2.ttl \
   input-3.json

--- a/tests/case_sparql_select/Makefile
+++ b/tests/case_sparql_select/Makefile
@@ -52,6 +52,7 @@ clean:
 
 output.%: \
   $(tests_srcdir)/.venv.done.log \
+  $(top_srcdir)/case_utils/case_sparql_select/__init__.py \
   input-1.sparql \
   input-2.ttl \
   input-3.json


### PR DESCRIPTION
This speeds local 'make check' round trips while developing, though at
the trade of having to push dependencies into more localized Make
recipes.

References:
* https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-e

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>