### PR TITLE
Add JSON-LD output code path test for case_sparql_construct

### DIFF
--- a/case_utils/case_sparql_construct/__init__.py
+++ b/case_utils/case_sparql_construct/__init__.py
@@ -78,7 +78,7 @@ def main():
       "format": output_format
     }
     if output_format == "json-ld":
-        context_dictionary = {k:v for (k,v) in graph.namespace_manager.namespaces()}
+        context_dictionary = {k:v for (k,v) in out_graph.namespace_manager.namespaces()}
         serialize_kwargs["context"] = context_dictionary
 
     out_graph.serialize(args.out_graph, **serialize_kwargs)

--- a/tests/case_sparql_construct/.gitignore
+++ b/tests/case_sparql_construct/.gitignore
@@ -1,1 +1,2 @@
+output.json
 output.ttl

--- a/tests/case_sparql_construct/Makefile
+++ b/tests/case_sparql_construct/Makefile
@@ -21,6 +21,7 @@ all: \
   output.ttl
 
 check: \
+  output.json \
   output.ttl
 	source $(tests_srcdir)/venv/bin/activate \
 	  && pytest \
@@ -30,10 +31,10 @@ clean:
 	@rm -rf \
 	  __pycache__
 	@rm -f \
-	  output.ttl \
+	  output.* \
 	  _*
 
-output.ttl: \
+output.%: \
   $(tests_srcdir)/.venv.done.log \
   $(top_srcdir)/case_utils/case_sparql_construct/__init__.py \
   input-1.sparql \

--- a/tests/case_sparql_construct/test_case_sparql_construct.py
+++ b/tests/case_sparql_construct/test_case_sparql_construct.py
@@ -15,7 +15,7 @@ import rdflib.plugins.sparql
 
 import case_utils
 
-def test_templates_with_blank_nodes_result():
+def _test_templates_with_blank_nodes_result(filename):
     ground_truth_positive = {
       ("Alice", "Hacker"),
       ("Bob", "Hacker")
@@ -23,7 +23,7 @@ def test_templates_with_blank_nodes_result():
     ground_truth_negative = set()
 
     graph = rdflib.Graph()
-    graph.parse("output.ttl", format=case_utils.guess_format("output.ttl"))
+    graph.parse(filename, format=case_utils.guess_format(filename))
 
     computed = set()
     query_string = """\
@@ -47,3 +47,8 @@ WHERE {
           l_family_name.toPython()
         ))
     assert computed == ground_truth_positive
+
+def test_templates_with_blank_nodes_result_json():
+    _test_templates_with_blank_nodes_result("output.json")
+def test_templates_with_blank_nodes_result_turtle():
+    _test_templates_with_blank_nodes_result("output.ttl")


### PR DESCRIPTION
Issue encountered while testing for AC-182.

References:
* [AC-178] Add website repository's sample runner to
  CASE-Utilities-Python repository
* [AC-182] Have website track CASE-Utilities-Python as submodule

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>