### PR TITLE
Fix unused variable reference

### DIFF
--- a/tests/case_utils/case_file/test_case_file.py
+++ b/tests/case_utils/case_file/test_case_file.py
@@ -122,14 +122,14 @@ WHERE {
     )
 
     n_observable_object = None
-    for result in graph_case_file_disable_hashes.query(query_confirm_mtime):
+    for result in graph_case_file_disable_hashes.query(query_object):
         (n_observable_object,) = result
     assert (
         not n_observable_object is None
     ), "File object with expected mtime not found in hashless graph."
 
     n_observable_object = None
-    for result in graph_case_file.query(query_confirm_mtime):
+    for result in graph_case_file.query(query_object):
         (n_observable_object,) = result
     assert (
         not n_observable_object is None


### PR DESCRIPTION
A recent update in rdflib no longer infers the xsd prefix with the usage
of the unprepared string query accidentally used before this commit.
The `.prepareQuery` results should have been used here.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>