### PR TITLE
Run CI on Python 3.11

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         python-version: 
           - '3.7'
-          - '3.10'
+          - '3.11'
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
[Python 3.11 was released today](https://www.python.org/downloads/release/python-3110/).

This pull request expands the CI "earliest vs. latest" coverage to go up to 3.11 instead of 3.10.

It looks like some dependencies will need to catch up before CI can take advantage of 3.11, including Github Actions and `rdflib`.  The CI for this PR should be re-triggered whenever someone thinks the dependencies support 3.11.