### PR TITLE
Fix configuration syntax for new IRIs file export

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,9 @@ console_scripts =
 
 [options.package_data]
 case_utils = py.typed
-case_utils.ontology = *.ttl ontology_and_version_iris.txt
+case_utils.ontology =
+    *.ttl
+    ontology_and_version_iris.txt
 
 [flake8]
 # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8


### PR DESCRIPTION
This is a correction to [PR 78](https://github.com/casework/CASE-Utilities-Python/pull/78).  CI did not detect the error because it takes removing `--editable` from the virtual environment setup to trigger the error.