### PR TITLE
case_sparql_select: Add flags to disable headers and row index numbers

### DIFF
--- a/tests/case_utils/Makefile
+++ b/tests/case_utils/Makefile
@@ -65,6 +65,7 @@ check: \
 	  && pytest \
 	    --ignore case_file \
 	    --ignore case_sparql_construct \
+	    --ignore case_sparql_select \
 	    --ignore case_validate \
 	    --log-level=DEBUG
 

--- a/tests/case_utils/case_sparql_select/.check-w3-output-with_header-with_index.csv
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-with_header-with_index.csv
@@ -1,0 +1,3 @@
+,?name,?mbox
+0,Johnny Lee Outlaw,mailto:jlow@example.com
+1,Peter Goodguy,mailto:peter@example.org

--- a/tests/case_utils/case_sparql_select/.check-w3-output-with_header-with_index.html
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-with_header-with_index.html
@@ -1,0 +1,21 @@
+<table border="1" class="dataframe table table-bordered table-condensed">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>?name</th>
+      <th>?mbox</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>Johnny Lee Outlaw</td>
+      <td>mailto:jlow@example.com</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>Peter Goodguy</td>
+      <td>mailto:peter@example.org</td>
+    </tr>
+  </tbody>
+</table>

--- a/tests/case_utils/case_sparql_select/.check-w3-output-with_header-with_index.md
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-with_header-with_index.md
@@ -1,0 +1,4 @@
+|    | ?name             | ?mbox                    |
+|----|-------------------|--------------------------|
+|  0 | Johnny Lee Outlaw | mailto:jlow@example.com  |
+|  1 | Peter Goodguy     | mailto:peter@example.org |

--- a/tests/case_utils/case_sparql_select/.check-w3-output-with_header-with_index.tsv
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-with_header-with_index.tsv
@@ -1,0 +1,3 @@
+	?name	?mbox
+0	Johnny Lee Outlaw	mailto:jlow@example.com
+1	Peter Goodguy	mailto:peter@example.org

--- a/tests/case_utils/case_sparql_select/.check-w3-output-with_header-without_index.csv
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-with_header-without_index.csv
@@ -1,0 +1,3 @@
+?name,?mbox
+Johnny Lee Outlaw,mailto:jlow@example.com
+Peter Goodguy,mailto:peter@example.org

--- a/tests/case_utils/case_sparql_select/.check-w3-output-with_header-without_index.html
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-with_header-without_index.html
@@ -1,0 +1,18 @@
+<table border="1" class="dataframe table table-bordered table-condensed">
+  <thead>
+    <tr style="text-align: right;">
+      <th>?name</th>
+      <th>?mbox</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Johnny Lee Outlaw</td>
+      <td>mailto:jlow@example.com</td>
+    </tr>
+    <tr>
+      <td>Peter Goodguy</td>
+      <td>mailto:peter@example.org</td>
+    </tr>
+  </tbody>
+</table>

--- a/tests/case_utils/case_sparql_select/.check-w3-output-with_header-without_index.md
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-with_header-without_index.md
@@ -1,0 +1,4 @@
+| ?name             | ?mbox                    |
+|-------------------|--------------------------|
+| Johnny Lee Outlaw | mailto:jlow@example.com  |
+| Peter Goodguy     | mailto:peter@example.org |

--- a/tests/case_utils/case_sparql_select/.check-w3-output-with_header-without_index.tsv
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-with_header-without_index.tsv
@@ -1,0 +1,3 @@
+?name	?mbox
+Johnny Lee Outlaw	mailto:jlow@example.com
+Peter Goodguy	mailto:peter@example.org

--- a/tests/case_utils/case_sparql_select/.check-w3-output-without_header-with_index.csv
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-without_header-with_index.csv
@@ -1,0 +1,2 @@
+0,Johnny Lee Outlaw,mailto:jlow@example.com
+1,Peter Goodguy,mailto:peter@example.org

--- a/tests/case_utils/case_sparql_select/.check-w3-output-without_header-with_index.html
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-without_header-with_index.html
@@ -1,0 +1,14 @@
+<table border="1" class="dataframe table table-bordered table-condensed">
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>Johnny Lee Outlaw</td>
+      <td>mailto:jlow@example.com</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>Peter Goodguy</td>
+      <td>mailto:peter@example.org</td>
+    </tr>
+  </tbody>
+</table>

--- a/tests/case_utils/case_sparql_select/.check-w3-output-without_header-with_index.md
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-without_header-with_index.md
@@ -1,0 +1,3 @@
+|---|-------------------|--------------------------|
+| 0 | Johnny Lee Outlaw | mailto:jlow@example.com  |
+| 1 | Peter Goodguy     | mailto:peter@example.org |

--- a/tests/case_utils/case_sparql_select/.check-w3-output-without_header-with_index.tsv
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-without_header-with_index.tsv
@@ -1,0 +1,2 @@
+0	Johnny Lee Outlaw	mailto:jlow@example.com
+1	Peter Goodguy	mailto:peter@example.org

--- a/tests/case_utils/case_sparql_select/.check-w3-output-without_header-without_index.csv
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-without_header-without_index.csv
@@ -1,0 +1,2 @@
+Johnny Lee Outlaw,mailto:jlow@example.com
+Peter Goodguy,mailto:peter@example.org

--- a/tests/case_utils/case_sparql_select/.check-w3-output-without_header-without_index.html
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-without_header-without_index.html
@@ -1,0 +1,12 @@
+<table border="1" class="dataframe table table-bordered table-condensed">
+  <tbody>
+    <tr>
+      <td>Johnny Lee Outlaw</td>
+      <td>mailto:jlow@example.com</td>
+    </tr>
+    <tr>
+      <td>Peter Goodguy</td>
+      <td>mailto:peter@example.org</td>
+    </tr>
+  </tbody>
+</table>

--- a/tests/case_utils/case_sparql_select/.check-w3-output-without_header-without_index.md
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-without_header-without_index.md
@@ -1,0 +1,3 @@
+|-------------------|--------------------------|
+| Johnny Lee Outlaw | mailto:jlow@example.com  |
+| Peter Goodguy     | mailto:peter@example.org |

--- a/tests/case_utils/case_sparql_select/.check-w3-output-without_header-without_index.tsv
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-without_header-without_index.tsv
@@ -1,0 +1,2 @@
+Johnny Lee Outlaw	mailto:jlow@example.com
+Peter Goodguy	mailto:peter@example.org

--- a/tests/case_utils/case_sparql_select/Makefile
+++ b/tests/case_utils/case_sparql_select/Makefile
@@ -50,6 +50,9 @@ check: \
   check-w3-tsv \
   check-prefixed_results \
   check-subclass
+	source $(tests_srcdir)/venv/bin/activate \
+	  && pytest \
+	    --log-level=DEBUG
 
 check-prefixed_results: \
   check-prefixed_results-csv \

--- a/tests/case_utils/case_sparql_select/test_data_frame_to_table_text_json.py
+++ b/tests/case_utils/case_sparql_select/test_data_frame_to_table_text_json.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+import pathlib
+import typing
+
+import pytest
+import rdflib
+
+import case_utils.case_sparql_select
+
+SRCDIR = pathlib.Path(__file__).parent
+
+GRAPH = rdflib.Graph()
+GRAPH.parse(str(SRCDIR / "w3-input-2.ttl"))
+GRAPH.parse(str(SRCDIR / "w3-input-3.json"))
+assert len(GRAPH) > 0
+
+SELECT_QUERY_TEXT: typing.Optional[str] = None
+with (SRCDIR / "w3-input-1.sparql").open("r") as _fh:
+    SELECT_QUERY_TEXT = _fh.read().strip()
+assert SELECT_QUERY_TEXT is not None
+
+DATA_FRAME = case_utils.case_sparql_select.graph_and_query_to_data_frame(
+    GRAPH, SELECT_QUERY_TEXT
+)
+
+
+def make_data_frame_to_json_table_text_parameters() -> typing.Iterator[
+    typing.Tuple[str, bool, bool]
+]:
+    for use_header in [False, True]:
+        for use_index in [False, True]:
+            for output_mode in ["csv", "html", "md", "tsv"]:
+                yield (output_mode, use_header, use_index)
+
+
+@pytest.mark.parametrize(
+    "output_mode, use_header, use_index",
+    make_data_frame_to_json_table_text_parameters(),
+)
+def test_data_frame_to_table_text_json(
+    output_mode: str,
+    use_header: bool,
+    use_index: bool,
+) -> None:
+    table_text = case_utils.case_sparql_select.data_frame_to_table_text(
+        DATA_FRAME,
+        output_mode=output_mode,
+        use_header=use_header,
+        use_index=use_index,
+    )
+
+    output_filename_template = ".check-w3-output-%s_header-%s_index.%s"
+    header_part = "with" if use_header else "without"
+    index_part = "with" if use_index else "without"
+    output_filename = output_filename_template % (
+        header_part,
+        index_part,
+        output_mode,
+    )
+    with (SRCDIR / output_filename).open("w") as out_fh:
+        out_fh.write(table_text)
+        if table_text[-1] != "\n":
+            out_fh.write("\n")


### PR DESCRIPTION
This patch series adds and tests `--no-header` and `--no-index` for `case_sparql_select`.  The flags disable output for some use cases that do not benefit from the annotations.  For instance:

* Generated query results in Git-tracked output change all rows following any result additions in the middle, due to the row number incrementing.  `--no-index` instead lets each insertion be noted as an added line without other side-effect.
* When a single column is generated as a CSV or TSV, it is possible the user will have enough knowledge of that "Flat file's" purpose that the header is unnecessary, and possibly a nuisance to downstream consumption.  `--no-header` removes the header without post-processing.

This should be merged after #90 is merged, as it is built on the patch in 90.

There are non-trivial effects on this patch series from #91, so if #91 is merged first, this patch series should catch up with `develop`.