### PR TITLE
Schedule recurring CI cron job

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -23,6 +23,8 @@ on:
   release:
     types:
       - published
+  schedule:
+    - cron: '15 5 * * TUE'
 
 jobs:
   build:


### PR DESCRIPTION
This will have the benefit of catching when an upstream updated package introduces a compatibility issue.

This cron job should trigger to leave notices for maintainers on the US East Coast to see on their Tuesday mornings.

*PR Note: This will probably fail CI on its first pass, due to a recent update to NumPy that removed Python 3.7 support.  That will be addressed in a separate PR.*