### PR TITLE
Update Python support to reflect coming 3.7 EOL

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         python-version: 
-          - '3.7'
+          - '3.8'
           - '3.11'
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     requests
     tabulate
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Python 3.7 end of support is 2023-06-27.  Some projects `case-utils` includes in its dependencies, most recently NumPy, are ending their support for Python 3.7 ahead of this EOL.

Rather than hold `case-utils` back for another 6 months, this patch removes 3.7 from the test base, and will encourage downstream adopters to do the same, so updates for imported packages continue to be retrieved.