### PR TITLE
CASE Validation Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 build/
 case_utils.egg-info/
 dist/
+venv/

--- a/case_utils/case_validate/__init__.py
+++ b/case_utils/case_validate/__init__.py
@@ -60,17 +60,19 @@ class NonExistentCDOConceptWarning(UserWarning):
     """
     This class is used when a concept is encountered in the data graph that is not part of CDO ontologies, according to the --built-version flags and --ontology-graph flags.
     """
+
     pass
+
 
 class ValidationResult:
     """
     This class is used to represent the result of a validation.
     """
+
     Conforms: bool
     UndefinedConcepts: typing.Set[rdflib.URIRef]
     Graph: rdflib.Graph
     ValidationText: str
-    
 
 
 def concept_is_cdo_concept(n_concept: rdflib.URIRef) -> bool:

--- a/case_utils/case_validate/__init__.py
+++ b/case_utils/case_validate/__init__.py
@@ -71,7 +71,7 @@ class ValidationResult:
 
     Conforms: bool
     UndefinedConcepts: typing.Set[rdflib.URIRef]
-    Graph: rdflib.Graph
+    Graph: any
     ValidationText: str
 
 

--- a/case_utils/case_validate/__init__.py
+++ b/case_utils/case_validate/__init__.py
@@ -71,7 +71,7 @@ class ValidationResult:
 
     Conforms: bool
     UndefinedConcepts: typing.Set[rdflib.URIRef]
-    Graph: any
+    Graph: typing.Any
     ValidationText: str
 
 


### PR DESCRIPTION
Adds a `validate()` function to allow programmatic access to the CASE Validation function.

Example usage:

```python
from case_utils.case_validate import validate, ValidationResult
import argparse
import os

# Validate a case file
args: argparse.Namespace = argparse.Namespace()
args.in_graph = [os.path.abspath("location.json")]
args.built_version = 'case-1.2.0'
args.ontology_graph = []
args.format = 'human'
args.inference = 'none'
args.metashacl = False
args.abort = False
args.allow_infos = False
args.allow_warnings = False
args.debug = False
args.imports = False

result: ValidationResult = validate(args)

print(result.ValidationText)
```