### PR TITLE
case_validate: Default to None rather than "none"

### DIFF
--- a/case_utils/case_validate/__init__.py
+++ b/case_utils/case_validate/__init__.py
@@ -136,12 +136,12 @@ def main() -> None:
         action="store_true",
         help="(As with pyshacl CLI) Allow import of sub-graphs defined in statements with owl:imports.",
     )
+    # NOTE: The "ontology graph" in the --inference help is the mix of the SHACL shapes graph and OWL ontology (or RDFS schema) graph.
     parser.add_argument(
         "-i",
         "--inference",
         choices=("none", "rdfs", "owlrl", "both"),
-        default="none",
-        help='(As with pyshacl CLI) Choose a type of inferencing to run against the Data Graph before validating. Default is "none".',
+        help='(As with pyshacl CLI) Choose a type of inferencing to run against the Data Graph before validating. The default behavior if this flag is not provided is to behave as "none", if not using the --metashacl flag.  The default behavior when using the --metashacl flag will apply "rdfs" inferencing to the ontology graph, but the data graph will still have no inferencing applied.  If the --inference flag is provided, it will apply to both the ontology graph, and the data graph.',
     )
     parser.add_argument(
         "-m",


### PR DESCRIPTION
Defaulting to the string `"none"` has a functional consequence in downstream pySHACL operations, as encoded at the time of this writing (pySHACL version 0.23.0).  `inference` in the `pyshacl.validate(...)` arguments is propagated down two code paths that both impact the validation operation, but that use different default values.  The `--metashacl` (SHACL-SHACL validation graph for reviewing shape syntax)- aligned code path defaults to `rdfs` inference, and the `Validator` class defaults to the string `"none"`.