### PR TITLE
case_sparql_select: Update JSON index and orient parameter combinations

### DIFF
--- a/tests/case_utils/case_sparql_select/.check-w3-output-with_header-without_index-orient-records.json
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-with_header-without_index-orient-records.json
@@ -1,0 +1,1 @@
+[{"?name":"Johnny Lee Outlaw","?mbox":"mailto:jlow@example.com"},{"?name":"Peter Goodguy","?mbox":"mailto:peter@example.org"}]

--- a/tests/case_utils/case_sparql_select/.check-w3-output-with_header-without_index-orient-values.json
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-with_header-without_index-orient-values.json
@@ -1,0 +1,1 @@
+[["Johnny Lee Outlaw","mailto:jlow@example.com"],["Peter Goodguy","mailto:peter@example.org"]]

--- a/tests/case_utils/case_sparql_select/.check-w3-output-without_header-without_index-orient-records.json
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-without_header-without_index-orient-records.json
@@ -1,0 +1,1 @@
+[{"?name":"Johnny Lee Outlaw","?mbox":"mailto:jlow@example.com"},{"?name":"Peter Goodguy","?mbox":"mailto:peter@example.org"}]

--- a/tests/case_utils/case_sparql_select/.check-w3-output-without_header-without_index-orient-values.json
+++ b/tests/case_utils/case_sparql_select/.check-w3-output-without_header-without_index-orient-values.json
@@ -1,0 +1,1 @@
+[["Johnny Lee Outlaw","mailto:jlow@example.com"],["Peter Goodguy","mailto:peter@example.org"]]

--- a/tests/case_utils/case_sparql_select/test_data_frame_to_table_text_json.py
+++ b/tests/case_utils/case_sparql_select/test_data_frame_to_table_text_json.py
@@ -55,10 +55,22 @@ def make_data_frame_to_json_table_text_parameters() -> (
                         "values",
                     ]:
                         # Handle incompatible parameter pairings for JSON mode.
-                        if use_index is False:
-                            if json_orient not in {"split", "table"}:
+                        if use_index is True:
+                            if json_orient not in {
+                                "columns",
+                                "index",
+                                "split",
+                                "table",
+                            }:
                                 continue
-
+                        elif use_index is False:
+                            if json_orient not in {
+                                "records",
+                                "split",
+                                "table",
+                                "values",
+                            }:
+                                continue
                         yield (json_orient, output_mode, use_header, use_index)
                 else:
                     yield ("columns", output_mode, use_header, use_index)


### PR DESCRIPTION
This is a bugfix PR, catching up a parameter-permuting test with revised behavior from Pandas.