### PR TITLE
Release 0.14.1

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -16,13 +16,15 @@ name: Continuous Integration
 
 on:
   push:
-    branches: 
+    branches:
       - main
       - develop
+      - support-*
   pull_request:
-    branches: 
+    branches:
       - main
       - develop
+      - support-*
   release:
     types:
       - published
@@ -35,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: 
+        python-version:
           - '3.9'
           - '3.12'
 
@@ -57,7 +59,7 @@ jobs:
       run: make clean
     - name: Run tests
       run: make PYTHON3=python check
-    
+
     # Build the binary wheel as well as the source tar
     - name: Build Objects
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 23.12.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)

--- a/case_utils/__init__.py
+++ b/case_utils/__init__.py
@@ -14,6 +14,6 @@
 #
 # We would appreciate acknowledgement if the software is used.
 
-__version__ = "0.14.0"
+__version__ = "0.14.1"
 
 from . import local_uuid  # noqa: F401

--- a/case_utils/local_uuid.py
+++ b/case_utils/local_uuid.py
@@ -39,11 +39,27 @@ DEMO_UUID_COUNTER: int = 0
 _logger = logging.getLogger(pathlib.Path(__file__).name)
 
 
+def _is_relative_to(p1: pathlib.Path, p2: pathlib.Path) -> bool:
+    """
+    This function provides pathlib.is_relative_to to Pythons before 3.9.  After the End of Life of Python 3.8, this function can be removed.
+    """
+    if sys.version_info < (3, 9):
+        try:
+            _ = p1.relative_to(p2)
+            return True
+        except ValueError:
+            return False
+    else:
+        return p1.is_relative_to(p2)
+
+
 def configure() -> None:
     """
     This function is part of setting up _demo_uuid() to generate non-random UUIDs.  See _demo_uuid() documentation for further setup notes.
     """
     global DEMO_UUID_BASE
+
+    # _logger.debug("sys.argv = %r.", sys.argv)
 
     if os.getenv("DEMO_UUID_REQUESTING_NONRANDOM") == "NONRANDOM_REQUESTED":
         warnings.warn(
@@ -94,18 +110,23 @@ def configure() -> None:
         demo_uuid_base_parts.append(sys.argv[0])
     else:
         command_original_path = pathlib.Path(sys.argv[0])
+        # _logger.debug("command_original_path = %r.", command_original_path)
         command_resolved_path = command_original_path.resolve()
+        # _logger.debug("command_resolved_path = %r.", command_resolved_path)
+
+        # The command could be a command embedded in a virtual
+        # environment, or it could be a script external to any virtual
+        # environment.
         venv_original_path = pathlib.Path(env_venv_name)
         venv_resolved_path = venv_original_path.resolve()
-        try:
+        if _is_relative_to(command_resolved_path, venv_resolved_path):
             command_relative_path = command_resolved_path.relative_to(
                 venv_resolved_path
             )
             # _logger.debug("command_relative_path = %r.", command_relative_path)
             demo_uuid_base_parts.append(str(command_relative_path))
-        except ValueError:
-            # _logger.debug("Command path is not relative to virtual environment path.")
-            demo_uuid_base_parts.append(str(command_resolved_path))
+        else:
+            demo_uuid_base_parts.append(str(command_original_path))
 
     if len(sys.argv) > 1:
         # Component: Arguments of argument vector.

--- a/tests/case_utils/case_validate/uco_test_examples/Makefile
+++ b/tests/case_utils/case_validate/uco_test_examples/Makefile
@@ -18,9 +18,7 @@ SHELL := /bin/bash
 
 top_srcdir := $(shell cd ../../../.. ; pwd)
 
-case_srcdir := $(top_srcdir)/dependencies/CASE
-
-uco_srcdir := $(case_srcdir)/dependencies/UCO
+uco_srcdir := $(top_srcdir)/dependencies/CASE/dependencies/UCO
 
 examples_srcdir := $(uco_srcdir)/tests/examples
 


### PR DESCRIPTION
Review notes for this PR:

* This applies a fix against `case-utils` 0.5.0, mostly following the Git-Flow practice for HotFix branches.  The initial patch was made from `main` at 0.5.0.  However, the [original 2010 documentation page](https://nvie.com/posts/a-successful-git-branching-model/) does not include practices for HotFix patches on releases older than the current release.  Other documentation, e.g. [here](https://gitversion.net/docs/learn/branching-strategies/gitflow/examples)[^1], demonstrates "Support" branches, but not a general practice on how to finally "Catch up" to the current `main`.  (This is not intended as a criticism - it just seems there remains creative latitude in how to do so.)
   - This PR instead just tries to guarantee each commit passes CI, so intermediary 0.x.1 releases can be pushed expecting to pass CI.
* There was some turbulence for backporting against releases between around 0.6.1 through around 0.10.1, due to one of the `pre-commit` packages encountering a known issue around that time.  So, as necessary scope creep, the backported fixes include running `pre-commit autoupdate` fairly early on.
* This PR targets `main` for a 0.14.1 release, and a sibling PR will target `develop` to apply the HotFix to `develop` and PR #144 .

[^1]: Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.