### PR TITLE
Release 0.14.1.post0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.12.0
+    rev: 23.12.1
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort

--- a/case_utils/__init__.py
+++ b/case_utils/__init__.py
@@ -14,6 +14,6 @@
 #
 # We would appreciate acknowledgement if the software is used.
 
-__version__ = "0.14.1"
+__version__ = "0.14.1.post0"
 
 from . import local_uuid  # noqa: F401

--- a/case_utils/local_uuid.py
+++ b/case_utils/local_uuid.py
@@ -20,7 +20,7 @@ This library is a wrapper for uuid, provided to generate repeatable UUIDs if req
 The function local_uuid() should be used in code where a user could be expected to opt in to non-random UUIDs.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 __all__ = ["configure", "local_uuid"]
 


### PR DESCRIPTION
This PR adds a missed module version increment for `case_utils.local_uuid` atop of `0.8.1`, and if accepted, will induce the following releases:

* `0.8.1.post0`
* `0.9.1.post0`
* `0.10.1.post0`
* `0.11.1.post0`
* `0.12.1.post0`
* `0.13.1.post0`
* `0.14.1.post0`

The version increment was missed because `case-utils` version `0.8.0` updated the module version to the same string.  The following two tables provide the originally released `local_uuid.py` versions (in the `0.x.0` releases), and their releases in late December (`0.x.1`, plus `0.5.1.post0`) and as proposed in this PR (`0.x.1.post0`, `x >= 8`).

| `case-utils` | `local_uuid.py` |
| --- | --- |
| `0.5.0` | `0.3.0` |
| `0.6.0` | `0.3.0` |
| `0.7.0` | `0.3.0` |
| `0.8.0` | `0.3.1` |
| `0.9.0` | `0.3.1` |
| `0.10.0` | `0.3.2` |
| `0.11.0` | `0.3.2` |
| `0.12.0` | `0.4.0` |
| `0.13.0` | `0.4.0` |
| `0.14.0` | `0.4.0` |

| `case-utils` | `local_uuid.py` |
| --- | --- |
| `0.5.1` | `0.3.0` |
| `0.5.1.post0` | `0.3.1` |
| `0.6.1` | `0.3.1` |
| `0.7.1` | `0.3.1` |
| `0.8.1` | `0.3.1` |
| `0.8.1.post0` | `0.3.2` |
| `0.9.1` | `0.3.1` |
| `0.9.1.post0` | `0.3.2` |
| `0.10.1` | `0.3.2` |
| `0.10.1.post0` | `0.3.3` |
| `0.11.1` | `0.3.2` |
| `0.11.1.post0` | `0.3.3` |
| `0.12.1` | `0.4.0` |
| `0.12.1.post0` | `0.4.1` |
| `0.13.1` | `0.4.0` |
| `0.13.1.post0` | `0.4.1` |
| `0.14.1` | `0.4.0` |
| `0.14.1.post0` | `0.4.1` |

There is also a bump of `pre-commit` version pins so the prerelease review passes.