### PR TITLE
Bump GitHub Actions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -42,13 +42,13 @@ jobs:
           - '3.12'
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '11'
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Pre-commit Checks
@@ -73,7 +73,7 @@ jobs:
 
     # Upload the packages on all develop and main pipleines for test consumption
     - name: Upload HTML Docs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: packages
         path: ./dist/

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -33,9 +33,9 @@ jobs:
           - '3.12'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Review dependencies


### PR DESCRIPTION
This PR bumps action versions.  I'm not sure whether CI will pass, but I do believe this is necessary regardless of CI passing because recent Action logs note some of the current Action versions use deprecated functionality.