### PR TITLE
Use `build`

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -63,8 +63,8 @@ jobs:
     # Build the binary wheel as well as the source tar
     - name: Build Objects
       run: |
-        pip install -q twine wheel
-        python setup.py sdist bdist_wheel
+        pip install -q twine build
+        python -m build
 
     # Ensure the objects were packaged correctly and there wasn't an issue with
     # the compilation or packaging process.


### PR DESCRIPTION
This tries to move past deprecation of `setup.py` functionality.

References:
* https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html#summary