### PR TITLE
Update pySHACL import to recognize typing

### DIFF
--- a/case_utils/case_validate/__init__.py
+++ b/case_utils/case_validate/__init__.py
@@ -41,7 +41,7 @@ import sys
 import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import pyshacl  # type: ignore
+import pyshacl
 import rdflib
 from rdflib import Graph
 

--- a/tests/case_utils/case_validate/cli/README.md
+++ b/tests/case_utils/case_validate/cli/README.md
@@ -1,0 +1,1 @@
+*Note*: Some files in this directory have contents incongruous with their file extension.  This is a test of whether the `--format` flag overrides the file name detection, so incongruities are expected.

--- a/tests/case_utils/case_validate/cli/format_jsonld_output_jsonld.jsonld
+++ b/tests/case_utils/case_validate/cli/format_jsonld_output_jsonld.jsonld
@@ -5,6 +5,7 @@
     ],
     "http://www.w3.org/ns/shacl#conforms": [
       {
+        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
         "@value": true
       }
     ]

--- a/tests/case_utils/case_validate/cli/format_jsonld_output_turtle.ttl
+++ b/tests/case_utils/case_validate/cli/format_jsonld_output_turtle.ttl
@@ -5,6 +5,7 @@
     ],
     "http://www.w3.org/ns/shacl#conforms": [
       {
+        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
         "@value": true
       }
     ]

--- a/tests/case_utils/case_validate/cli/format_jsonld_output_txt.txt
+++ b/tests/case_utils/case_validate/cli/format_jsonld_output_txt.txt
@@ -5,6 +5,7 @@
     ],
     "http://www.w3.org/ns/shacl#conforms": [
       {
+        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
         "@value": true
       }
     ]

--- a/tests/case_utils/case_validate/cli/format_jsonld_output_unspecified.jsonld
+++ b/tests/case_utils/case_validate/cli/format_jsonld_output_unspecified.jsonld
@@ -5,6 +5,7 @@
     ],
     "http://www.w3.org/ns/shacl#conforms": [
       {
+        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
         "@value": true
       }
     ]

--- a/tests/case_utils/case_validate/uco_test_examples/co_XFAIL_validation.ttl
+++ b/tests/case_utils/case_validate/uco_test_examples/co_XFAIL_validation.ttl
@@ -78,7 +78,7 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/list-item-4361eb9c-a1c2-40e7-ba83-92802554392a> ;
-			sh:resultMessage 'Node kb:list-item-4361eb9c-a1c2-40e7-ba83-92802554392a conforms to shape [ rdf:type sh:PropertyShape ; sh:class co:Item ; sh:description Literal("This shape encodes in SHACL that the range of co:itemContent is the complement of co:Item.", lang=en) ; sh:path co:itemContent ]' ;
+			sh:resultMessage 'Node kb:list-item-4361eb9c-a1c2-40e7-ba83-92802554392a must not conform to shape [ rdf:type sh:PropertyShape ; sh:class co:Item ; sh:description Literal("This shape encodes in SHACL that the range of co:itemContent is the complement of co:Item.", lang=en) ; sh:path co:itemContent ]' ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:NotConstraintComponent ;
 			sh:sourceShape uco-co:itemContent-subjects-shape ;

--- a/tests/case_utils/case_validate/uco_test_examples/configuration_setting_XFAIL_validation.ttl
+++ b/tests/case_utils/case_validate/uco_test_examples/configuration_setting_XFAIL_validation.ttl
@@ -13,7 +13,7 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/configuration-entry-5f0fc3ea-e763-4b6d-997a-be0d1ceffc8c> ;
-			sh:resultMessage 'Node kb:configuration-entry-5f0fc3ea-e763-4b6d-997a-be0d1ceffc8c does not conform to exactly one shape in [ sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path configuration:itemObject ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path configuration:itemValue ] ] , [ sh:property [ sh:minCount Literal("1", datatype=xsd:integer) ; sh:path configuration:itemObject ] ] , [ sh:property [ sh:minCount Literal("1", datatype=xsd:integer) ; sh:path configuration:itemValue ] ]' ;
+			sh:resultMessage 'Node kb:configuration-entry-5f0fc3ea-e763-4b6d-997a-be0d1ceffc8c must conform to exactly one shape in [ sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path configuration:itemObject ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path configuration:itemValue ] ] , [ sh:property [ sh:minCount Literal("1", datatype=xsd:integer) ; sh:path configuration:itemObject ] ] , [ sh:property [ sh:minCount Literal("1", datatype=xsd:integer) ; sh:path configuration:itemValue ] ]' ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:XoneConstraintComponent ;
 			sh:sourceShape configuration:ConfigurationEntry ;

--- a/tests/case_utils/case_validate/uco_test_examples/database_records_XFAIL_validation.ttl
+++ b/tests/case_utils/case_validate/uco_test_examples/database_records_XFAIL_validation.ttl
@@ -12,7 +12,7 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/table-field-facet-37182dba-4dbd-4b97-b49e-8038b7fbfd29> ;
-			sh:resultMessage 'Node kb:table-field-facet-37182dba-4dbd-4b97-b49e-8038b7fbfd29 does not conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("false" = False, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("true" = True, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldValue ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldIsNull ] ]' ;
+			sh:resultMessage 'Node kb:table-field-facet-37182dba-4dbd-4b97-b49e-8038b7fbfd29 must conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("false" = False, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("true" = True, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldValue ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldIsNull ] ]' ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:XoneConstraintComponent ;
 			sh:sourceShape observable:TableFieldFacet ;
@@ -35,7 +35,7 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314> ;
-			sh:resultMessage 'Node kb:table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314 does not conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("false" = False, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("true" = True, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldValue ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldIsNull ] ]' ;
+			sh:resultMessage 'Node kb:table-field-facet-46aafb6e-0be4-4412-a938-16c4b5ae5314 must conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("false" = False, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:hasValue Literal("true" = True, datatype=xsd:boolean) ; sh:path observable:recordFieldIsNull ], [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldValue ] ] , [ rdf:type sh:NodeShape ; sh:property [ sh:maxCount Literal("0", datatype=xsd:integer) ; sh:path observable:recordFieldIsNull ] ]' ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:XoneConstraintComponent ;
 			sh:sourceShape observable:TableFieldFacet ;

--- a/tests/case_utils/case_validate/uco_test_examples/hash_XFAIL_validation.ttl
+++ b/tests/case_utils/case_validate/uco_test_examples/hash_XFAIL_validation.ttl
@@ -78,7 +78,7 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/hash-f46c714f-559a-4325-bf8a-4ef60c92c771> ;
-			sh:resultMessage 'Node Literal("1", datatype=xsd:integer) does not conform to one or more shapes in [ sh:datatype vocabulary:HashNameVocab ] , [ sh:datatype xsd:string ]' ;
+			sh:resultMessage 'Node Literal("1", datatype=xsd:integer) must conform to one or more shapes in [ sh:datatype vocabulary:HashNameVocab ] , [ sh:datatype xsd:string ]' ;
 			sh:resultPath types:hashMethod ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:OrConstraintComponent ;

--- a/tests/case_utils/case_validate/uco_test_examples/rdf_list_XFAIL_validation.ttl
+++ b/tests/case_utils/case_validate/uco_test_examples/rdf_list_XFAIL_validation.ttl
@@ -14,7 +14,7 @@
 			sh:detail [
 				a sh:ValidationResult ;
 				sh:focusNode <http://example.org/kb/list-1> ;
-				sh:resultMessage 'Node kb:list-1 does not conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] , [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:path [ sh:oneOrMorePath rdf:rest ] ; sh:xone ( [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:maxCount Literal("1", datatype=xsd:integer) ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:path rdf:first ] ] ) ] ]' ;
+				sh:resultMessage 'Node kb:list-1 must conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] , [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:path [ sh:oneOrMorePath rdf:rest ] ; sh:xone ( [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:maxCount Literal("1", datatype=xsd:integer) ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:path rdf:first ] ] ) ] ]' ;
 				sh:resultSeverity sh:Violation ;
 				sh:sourceConstraintComponent sh:XoneConstraintComponent ;
 				sh:sourceShape uco-owl:Sequence-shape ;
@@ -40,7 +40,7 @@
 			sh:detail [
 				a sh:ValidationResult ;
 				sh:focusNode <http://example.org/ontology/someDatatypeProperty> ;
-				sh:resultMessage 'Node ex:someDatatypeProperty does not conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] , [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:path [ sh:oneOrMorePath rdf:rest ] ; sh:xone ( [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:maxCount Literal("1", datatype=xsd:integer) ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:path rdf:first ] ] ) ] ]' ;
+				sh:resultMessage 'Node ex:someDatatypeProperty must conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] , [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:path [ sh:oneOrMorePath rdf:rest ] ; sh:xone ( [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:maxCount Literal("1", datatype=xsd:integer) ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:path rdf:first ] ] ) ] ]' ;
 				sh:resultSeverity sh:Violation ;
 				sh:sourceConstraintComponent sh:XoneConstraintComponent ;
 				sh:sourceShape uco-owl:Sequence-shape ;
@@ -66,7 +66,7 @@
 					<http://example.org/kb/concept-7>
 					<http://example.org/kb/concept-8>
 				) ;
-				sh:resultMessage 'Node ( kb:concept-7 kb:concept-8 ) does not conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] , [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:path [ sh:oneOrMorePath rdf:rest ] ; sh:xone ( [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:maxCount Literal("1", datatype=xsd:integer) ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:path rdf:first ] ] ) ] ]' ;
+				sh:resultMessage 'Node ( kb:concept-7 kb:concept-8 ) must conform to exactly one shape in [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] , [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:path [ sh:oneOrMorePath rdf:rest ] ; sh:xone ( [ rdf:type sh:NodeShape ; sh:hasValue rdf:nil ] [ rdf:type sh:NodeShape ; sh:nodeKind sh:BlankNode ; sh:property [ rdf:type sh:PropertyShape ; sh:maxCount Literal("1", datatype=xsd:integer) ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:path rdf:first ] ] ) ] ]' ;
 				sh:resultSeverity sh:Violation ;
 				sh:sourceConstraintComponent sh:XoneConstraintComponent ;
 				sh:sourceShape uco-owl:Sequence-shape ;

--- a/tests/case_utils/case_validate/uco_test_examples/thread_XFAIL_validation.ttl
+++ b/tests/case_utils/case_validate/uco_test_examples/thread_XFAIL_validation.ttl
@@ -48,7 +48,7 @@
 		[
 			a sh:ValidationResult ;
 			sh:focusNode <http://example.org/kb/thread-item-2bd09467-d413-4a03-af5d-f0e428f7d987> ;
-			sh:resultMessage 'Node kb:thread-item-2bd09467-d413-4a03-af5d-f0e428f7d987 conforms to shape [ rdf:type sh:PropertyShape ; sh:class co:Item ; sh:description Literal("This shape encodes in SHACL that the range of co:itemContent is the complement of co:Item.", lang=en) ; sh:path co:itemContent ]' ;
+			sh:resultMessage 'Node kb:thread-item-2bd09467-d413-4a03-af5d-f0e428f7d987 must not conform to shape [ rdf:type sh:PropertyShape ; sh:class co:Item ; sh:description Literal("This shape encodes in SHACL that the range of co:itemContent is the complement of co:Item.", lang=en) ; sh:path co:itemContent ]' ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:NotConstraintComponent ;
 			sh:sourceShape uco-co:itemContent-subjects-shape ;


### PR DESCRIPTION
Other effects of pySHACL recent releases were observed on Make-managed files, unrelated to removing the ignore-typing designation.